### PR TITLE
Set GtkComponent 'visible' prop before user defined props

### DIFF
--- a/pyract/view.py
+++ b/pyract/view.py
@@ -81,10 +81,10 @@ class GtkComponent(BaseComponent):
         self._type = type_
         self._instance = type_()
 
-        self.update(props.items())
         if not issubclass(self._type, Gtk.Popover):
             # visible=True is a default prop
             self.update([('visible', True)])
+        self.update(props.items())
 
     def update(self, updated_list=[]):
         for k, v in updated_list:


### PR DESCRIPTION
Prevent 'visible' prop default value to override user defined one.
"counter.py" correctly hide "reset" button at startup.